### PR TITLE
convert computation to fp32

### DIFF
--- a/fm_test.ipynb
+++ b/fm_test.ipynb
@@ -2,10 +2,27 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "2900d09b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using /home/lexion/.cache/torch_extensions/py38_cu121 as PyTorch extensions root...\n",
+      "Creating extension directory /home/lexion/.cache/torch_extensions/py38_cu121/fm_scan...\n",
+      "Detected CUDA files, patching ldflags\n",
+      "Emitting ninja build file /home/lexion/.cache/torch_extensions/py38_cu121/fm_scan/build.ninja...\n",
+      "/home/lexion/anaconda3/envs/p2/lib/python3.8/site-packages/torch/utils/cpp_extension.py:1965: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. \n",
+      "If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].\n",
+      "  warnings.warn(\n",
+      "Building extension module fm_scan...\n",
+      "Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)\n",
+      "Loading extension module fm_scan...\n"
+     ]
+    }
+   ],
    "source": [
     "import torch\n",
     "from fm.scan.fm_scan import fm_scan, fm_memory # c++ cuda kernel"
@@ -58,14 +75,25 @@
    "execution_count": null,
    "id": "4538a9ae",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(0.0012, device='cuda:0', dtype=torch.bfloat16, grad_fn=<MeanBackward0>)\n",
+      "tensor(0., device='cuda:0', dtype=torch.bfloat16, grad_fn=<MeanBackward0>)\n",
+      "tensor(0.9961, device='cuda:0', dtype=torch.bfloat16)\n",
+      "tensor(2.3125, device='cuda:0', dtype=torch.bfloat16)\n"
+     ]
+    }
+   ],
    "source": [
     "# check with pytorch\n",
     "from fm.scan.fm_pytorch import fm_scan_pytorch\n",
     "\n",
-    "batch_size, dim, seqlen, mem = 1, 5, 32, 1\n",
-    "gates = 0.5 + 0.5 * torch.rand(batch_size, mem, seqlen, device=\"cuda\", dtype=torch.float32)\n",
-    "tokens = torch.rand(batch_size, dim, seqlen, device=\"cuda\", dtype=torch.float32)\n",
+    "batch_size, dim, seqlen, mem = 1, 5, 1024, 1\n",
+    "gates = 0.5 + 0.5 * torch.rand(batch_size, mem, seqlen, device=\"cuda\", dtype=torch.bfloat16)\n",
+    "tokens = torch.rand(batch_size, dim, seqlen, device=\"cuda\", dtype=torch.bfloat16)\n",
     "\n",
     "tokens_cuda = tokens.clone().detach().requires_grad_()\n",
     "gates_cuda = gates.clone().detach().requires_grad_()\n",
@@ -77,23 +105,22 @@
     "loss_cuda = memory_states.sum()\n",
     "loss_cuda.backward()\n",
     "\n",
+    "gates_cuda32 = gates_cuda.clone().to(torch.float32)\n",
+    "tokens_cuda32 = tokens_cuda.clone().to(torch.float32)\n",
+    "\n",
+    "memory_states32 = fm_scan(gates_cuda, tokens_cuda, initial_state=None)\n",
+    "loss_cuda32 = memory_states32.sum()\n",
+    "loss_cuda32.backward()\n",
+    "\n",
     "# pytorch val\n",
     "memory_states_pytorch = fm_scan_pytorch(gates_pytorch, tokens_pytorch, initial_state=None)\n",
     "loss_pytorch = memory_states_pytorch.sum()\n",
     "loss_pytorch.backward()\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41408236",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(torch.sum(torch.abs(memory_states - memory_states_pytorch)))\n",
-    "print(torch.sum(torch.abs(tokens_cuda.grad - tokens_pytorch.grad)))\n",
-    "print(torch.sum(torch.abs(gates_cuda.grad - gates_pytorch.grad)))"
+    "\n",
+    "print(torch.mean(torch.abs(memory_states - memory_states_pytorch)))\n",
+    "print(torch.mean(torch.abs(memory_states32 - memory_states)))\n",
+    "print(torch.mean(torch.abs(tokens_cuda.grad - tokens_pytorch.grad)))\n",
+    "print(torch.mean(torch.abs(gates_cuda.grad - gates_pytorch.grad)))"
    ]
   }
  ],


### PR DESCRIPTION
change the kernel inner computation and temp variables into float32 regardless of whether its inputs are float32 to ensure compute accuracy.